### PR TITLE
Fix Tailwind PostCSS setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@tailwindcss/cli": "^4.1.14",
+        "@tailwindcss/postcss": "^4.1.14",
         "@vitejs/plugin-react": "^5.0.4",
         "tailwindcss": "^4.1.14",
         "vite": "^5.4.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.1.14",
+    "@tailwindcss/postcss": "^4.1.14",
     "@vitejs/plugin-react": "^5.0.4",
     "tailwindcss": "^4.1.14",
     "vite": "^5.4.0"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
+import tailwindcss from "@tailwindcss/postcss"
+
 export default {
-  plugins: {
-    tailwindcss: {},
-  },
+  plugins: [tailwindcss()],
 }

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ if (( TAILWIND_V3 == 0 )); then
   npm pkg delete devDependencies.postcss >/dev/null 2>&1 || true
   npm pkg delete devDependencies.autoprefixer >/dev/null 2>&1 || true
 
-  npm i -D @tailwindcss/cli tailwindcss@latest
+  npm i -D @tailwindcss/cli @tailwindcss/postcss tailwindcss@latest
 
   # init config (v4)
   npx @tailwindcss/cli init --postcss
@@ -75,6 +75,15 @@ export default {
 }
 EOF
   fi
+
+  # enforce Tailwind v4 PostCSS plugin usage
+  cat > postcss.config.js <<'EOF'
+import tailwindcss from "@tailwindcss/postcss"
+
+export default {
+  plugins: [tailwindcss()],
+}
+EOF
 
   # index.css with v4 import
   mkdir -p src


### PR DESCRIPTION
## Summary
- add the `@tailwindcss/postcss` dependency and use it from the PostCSS config
- update the Tailwind setup script to install and configure the new PostCSS plugin

## Testing
- `npm run build` *(fails: missing @tailwindcss/postcss in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5458c08648328a2e1b9cdc8f4abc4