### PR TITLE
Fix setup script for Tailwind v4 CLI change

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -62,19 +62,13 @@ if (( TAILWIND_V3 == 0 )); then
 
   npm i -D @tailwindcss/cli @tailwindcss/postcss tailwindcss@latest
 
-  # init config (v4)
-  npx @tailwindcss/cli init --postcss
-
-  # ensure content in config
-  if [[ -f tailwind.config.js ]]; then
-    # overwrite with minimal v4 config
-    cat > tailwind.config.js <<'EOF'
+  # ensure content in config (create minimal v4 config)
+  cat > tailwind.config.js <<'EOF'
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
 }
 EOF
-  fi
 
   # enforce Tailwind v4 PostCSS plugin usage
   cat > postcss.config.js <<'EOF'


### PR DESCRIPTION
## Summary
- remove the deprecated Tailwind CLI init command from the setup script
- generate the minimal Tailwind v4 config file directly during setup

## Testing
- ./setup.sh (fails: npm returned 403 fetching @tailwindcss/postcss)


------
https://chatgpt.com/codex/tasks/task_e_68e5486b4a6083289ff76a56ffe26ce4